### PR TITLE
fix: rimuovi indicatore confidence dall'importazione PDF

### DIFF
--- a/renderer/css/participants.css
+++ b/renderer/css/participants.css
@@ -2496,19 +2496,6 @@
   letter-spacing: 0.5px;
 }
 
-.doc-confidence {
-  color: #22c55e;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.doc-confidence::before {
-  content: '✓';
-}
-
 .doc-info-details {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/renderer/js/participants-manager.js
+++ b/renderer/js/participants-manager.js
@@ -2929,16 +2929,12 @@ function showPdfPreviewState(data) {
 
   // Update document info
   const docTypeBadge = document.getElementById('pdf-doc-type-badge');
-  const confidenceEl = document.getElementById('pdf-doc-confidence');
   const eventNameEl = document.getElementById('pdf-event-name');
   const categoryEl = document.getElementById('pdf-category-name');
   const participantsCountEl = document.getElementById('pdf-participants-count');
 
   if (docTypeBadge) {
     docTypeBadge.textContent = formatDocumentType(data.validation.document_type);
-  }
-  if (confidenceEl) {
-    confidenceEl.textContent = `${(data.validation.confidence * 100).toFixed(0)}% confidence`;
   }
   if (eventNameEl) {
     eventNameEl.textContent = data.event.name || 'Not detected';

--- a/renderer/pages/participants.html
+++ b/renderer/pages/participants.html
@@ -709,7 +709,6 @@
           <div class="pdf-document-info">
             <div class="doc-info-header">
               <span class="doc-type-badge" id="pdf-doc-type-badge">Entry List</span>
-              <span class="doc-confidence" id="pdf-doc-confidence">98% confidence</span>
             </div>
             <div class="doc-info-details">
               <div class="doc-info-item">


### PR DESCRIPTION
Rimuove l'indicatore di confidence dall'importazione PDF per evitare confusione.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)