### PR TITLE
fix(export): preserve all drivers in JSON round-trip

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -364,6 +364,7 @@
     });
   </script>
   <!-- Participants Management (must load before enhanced-file-browser) -->
+  <script src="js/driver-helpers.js"></script>
   <script src="js/participants-manager.js"></script>
   <script src="js/preset-iptc-editor.js"></script>
   <script src="js/preset-face-manager.js"></script>

--- a/renderer/js/driver-helpers.js
+++ b/renderer/js/driver-helpers.js
@@ -1,0 +1,100 @@
+/**
+ * Driver helpers — pure utilities for deriving driver data from preset
+ * participants in the renderer.
+ *
+ * Designed as a dual-export module so the same file is consumed by:
+ *   - the renderer (browser global `window.driverHelpers`, loaded via <script>)
+ *   - Jest tests (CommonJS `require('.../driver-helpers')`)
+ *
+ * No external dependencies, no DOM access, no IPC. Keep it that way.
+ *
+ * Background — why this exists:
+ *
+ *   The canonical store for per-participant drivers is the
+ *   `preset_participant_drivers` table (rows keyed by participant_id, sorted by
+ *   driver_order). However, presets imported from PDF (via Gemini extraction)
+ *   currently land all driver names in a single comma-separated string on the
+ *   `nome` column of `preset_participants`, and rows in
+ *   `preset_participant_drivers` are only created when the participant is
+ *   opened and saved through the editor.
+ *
+ *   On a fresh PDF import (e.g. Lisa's Nürburgring 24h preset, 161 entries),
+ *   only the participants the user has manually edited end up with driver
+ *   records — for every other participant, the export reads zero drivers and
+ *   silently drops drivers 2/3/4 from the JSON, even though the names are
+ *   visible in the UI grid (which falls back to splitting `nome`).
+ *
+ *   `synthesizeDriversFromNome` is the export-time fallback that mirrors the
+ *   UI's split logic, so an exported preset round-trips with all drivers
+ *   intact regardless of whether the user has opened each participant.
+ *
+ * See PLAN_BULK_FOLDER_ASSIGN.md (PR1) for the full context.
+ */
+(function (global) {
+  'use strict';
+
+  /**
+   * Synthesize driver records from a participant's `nome` string.
+   *
+   * Splitting policy: comma only. Other separators ("/", ";", " and ", etc.)
+   * are NOT split — keeping the contract narrow avoids corrupting freeform
+   * editorial values like "J. Smith / co-driver TBD". When a "/" is detected
+   * we surface a console warning so data-quality issues are visible during
+   * future cleanup work, but the value itself is preserved verbatim.
+   *
+   * @param {string} nome              Raw `nome` field from preset_participants.
+   * @param {string} participantNumero Race number, copied onto each emitted
+   *                                   driver record (mirrors the shape used
+   *                                   by exportPresetJSON's allDrivers array).
+   * @returns {Array<Object>} Driver records ready to be pushed into the
+   *                          export's top-level `drivers[]` array.
+   *                          Empty array for empty / non-string input.
+   */
+  function synthesizeDriversFromNome(nome, participantNumero) {
+    if (typeof nome !== 'string') return [];
+    const trimmed = nome.trim();
+    if (!trimmed) return [];
+
+    if (trimmed.indexOf('/') !== -1 && typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        '[driver-helpers] participant ' + participantNumero +
+        ': nome contains "/" — kept as-is, only "," is treated as separator. Value: ' +
+        JSON.stringify(trimmed)
+      );
+    }
+
+    const names = trimmed
+      .split(',')
+      .map(function (s) { return s.trim(); })
+      .filter(Boolean);
+
+    return names.map(function (name, idx) {
+      return {
+        id: _genId(),
+        participant_numero: participantNumero,
+        driver_name: name,
+        driver_metatag: null,
+        driver_nationality: '',
+        driver_order: idx
+      };
+    });
+  }
+
+  function _genId() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    return 'tmp-' + Math.random().toString(36).slice(2) + '-' + Date.now().toString(36);
+  }
+
+  const api = {
+    synthesizeDriversFromNome: synthesizeDriversFromNome
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  if (typeof window !== 'undefined') {
+    window.driverHelpers = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/renderer/js/participants-manager.js
+++ b/renderer/js/participants-manager.js
@@ -3218,7 +3218,20 @@ async function exportPresetJSON(presetId) {
 
     const preset = response.data;
 
-    // Fetch driver data for all participants
+    // Fetch driver data for all participants.
+    //
+    // The canonical source is the `preset_participant_drivers` table, but it
+    // is only populated for participants that have been opened/saved through
+    // the editor. PDF-imported presets land their multi-driver lineup in the
+    // legacy `nome` column (comma-separated) and never get individual driver
+    // rows until the user manually edits each row.
+    //
+    // Without the fallback below, exporting such a preset emits drivers only
+    // for the few participants that have been edited — for the rest, the
+    // top-level `drivers[]` array is empty and a round-trip silently loses
+    // drivers 2/3/4 even though the names are visible in the UI grid.
+    //
+    // See driver-helpers.js + PLAN_BULK_FOLDER_ASSIGN.md (PR1) for context.
     const allDrivers = [];
     for (const p of preset.participants || []) {
       const driversResult = await window.api.invoke('preset-get-drivers-for-participant', p.id);
@@ -3233,6 +3246,16 @@ async function exportPresetJSON(presetId) {
             driver_order: d.driver_order
           });
         });
+      } else if (p.nome && window.driverHelpers && window.driverHelpers.synthesizeDriversFromNome) {
+        // Legacy fallback: synthesize driver records by splitting `nome` on
+        // commas. Records get fresh UUIDs because they don't exist in the DB
+        // yet — on re-import, importJsonPreset will create them under these
+        // IDs. driver_metatag/nationality default to null/'' (PDF imports
+        // never have these for non-edited participants).
+        const synth = window.driverHelpers.synthesizeDriversFromNome(p.nome, p.numero);
+        for (const d of synth) {
+          allDrivers.push(d);
+        }
       }
     }
 

--- a/tests/driver-synthesis.test.ts
+++ b/tests/driver-synthesis.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for renderer-side driver helpers (driver-helpers.js).
+ *
+ * The helper is a pure function module — no DOM, no network, no IPC — so we
+ * can `require()` it directly in Jest without environment setup. It uses
+ * a dual-export pattern (CommonJS for tests, browser global for renderer).
+ *
+ * Coverage focus is the export-time fallback `synthesizeDriversFromNome`,
+ * which preserves multi-driver lineups when `preset_participant_drivers` is
+ * empty for a participant. See PR1 in PLAN_BULK_FOLDER_ASSIGN.md.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { synthesizeDriversFromNome } = require('../renderer/js/driver-helpers');
+
+interface SynthDriver {
+  id: string;
+  participant_numero: string;
+  driver_name: string;
+  driver_metatag: null;
+  driver_nationality: string;
+  driver_order: number;
+}
+
+describe('synthesizeDriversFromNome', () => {
+  describe('empty / null inputs', () => {
+    it('returns empty array for empty string', () => {
+      expect(synthesizeDriversFromNome('', '1')).toEqual([]);
+    });
+
+    it('returns empty array for null', () => {
+      expect(synthesizeDriversFromNome(null, '1')).toEqual([]);
+    });
+
+    it('returns empty array for undefined', () => {
+      expect(synthesizeDriversFromNome(undefined, '1')).toEqual([]);
+    });
+
+    it('returns empty array for whitespace-only', () => {
+      expect(synthesizeDriversFromNome('   \t  \n ', '1')).toEqual([]);
+    });
+
+    it('returns empty array for non-string inputs', () => {
+      expect(synthesizeDriversFromNome(42, '1')).toEqual([]);
+      expect(synthesizeDriversFromNome({}, '1')).toEqual([]);
+      expect(synthesizeDriversFromNome([], '1')).toEqual([]);
+    });
+  });
+
+  describe('single driver name', () => {
+    it('returns one driver record', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('Augusto Farfus', '1');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        participant_numero: '1',
+        driver_name: 'Augusto Farfus',
+        driver_metatag: null,
+        driver_nationality: '',
+        driver_order: 0
+      });
+      expect(typeof result[0].id).toBe('string');
+      expect(result[0].id.length).toBeGreaterThan(0);
+    });
+
+    it('trims whitespace around a single name', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('  Augusto Farfus  ', '1');
+      expect(result[0].driver_name).toBe('Augusto Farfus');
+    });
+  });
+
+  describe('multi-driver comma-separated', () => {
+    it('emits one record per name with sequential driver_order from 0', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome(
+        'Augusto Farfus, Raffaele Marciello, Jordan Pepper, Kelvin van der Linde',
+        '1'
+      );
+      expect(result).toHaveLength(4);
+      expect(result.map((d) => d.driver_name)).toEqual([
+        'Augusto Farfus',
+        'Raffaele Marciello',
+        'Jordan Pepper',
+        'Kelvin van der Linde'
+      ]);
+      expect(result.map((d) => d.driver_order)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('every emitted driver inherits the participant_numero', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('A, B, C', '447');
+      expect(result.every((d) => d.participant_numero === '447')).toBe(true);
+    });
+
+    it('trims whitespace around each split entry', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('  Hamilton  ,Verstappen  ,  Norris', '1');
+      expect(result.map((d) => d.driver_name)).toEqual(['Hamilton', 'Verstappen', 'Norris']);
+    });
+
+    it('drops empty entries from "A,,B" patterns', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('A,,B,, ,C', '1');
+      expect(result.map((d) => d.driver_name)).toEqual(['A', 'B', 'C']);
+      expect(result.map((d) => d.driver_order)).toEqual([0, 1, 2]);
+    });
+
+    it('generates a unique id per emitted driver', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('A, B, C, D, E, F, G, H', '1');
+      const ids = new Set(result.map((d) => d.id));
+      expect(ids.size).toBe(8);
+    });
+
+    it('handles names containing periods, hyphens, umlauts, accents', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome(
+        'J. Smith-Jones, Müller, Pérez, Jürgen Röss, Patricija Stalidzane',
+        '7'
+      );
+      expect(result).toHaveLength(5);
+      expect(result.map((d) => d.driver_name)).toEqual([
+        'J. Smith-Jones',
+        'Müller',
+        'Pérez',
+        'Jürgen Röss',
+        'Patricija Stalidzane'
+      ]);
+    });
+  });
+
+  describe('non-canonical separators (slash) — preserved as-is', () => {
+    let warnSpy: ReturnType<typeof jest.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT split on "/" — preserves the entire token', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('A / B', '1');
+      expect(result).toHaveLength(1);
+      expect(result[0].driver_name).toBe('A / B');
+    });
+
+    it('does NOT split on ";"', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('A;B;C', '1');
+      expect(result).toHaveLength(1);
+      expect(result[0].driver_name).toBe('A;B;C');
+    });
+
+    it('logs a warning when "/" is present so data-quality issues surface', () => {
+      synthesizeDriversFromNome('A / B', '99');
+      expect(warnSpy).toHaveBeenCalled();
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toContain('participant 99');
+      expect(msg).toContain('"/"');
+    });
+
+    it('does NOT warn when only commas are present', () => {
+      synthesizeDriversFromNome('A, B, C', '1');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves comma-then-slash mixed input — splits on comma only', () => {
+      // "Driver A, Driver B / co-driver TBD" → ["Driver A", "Driver B / co-driver TBD"]
+      const result: SynthDriver[] = synthesizeDriversFromNome('Driver A, Driver B / co-driver TBD', '1');
+      expect(result.map((d) => d.driver_name)).toEqual(['Driver A', 'Driver B / co-driver TBD']);
+    });
+  });
+
+  describe('shape contract — matches what exportPresetJSON consumes', () => {
+    it('every record has exactly the keys exportPresetJSON pushes into allDrivers', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('A, B', '99');
+      const expectedKeys = [
+        'id',
+        'participant_numero',
+        'driver_name',
+        'driver_metatag',
+        'driver_nationality',
+        'driver_order'
+      ].sort();
+      for (const d of result) {
+        expect(Object.keys(d).sort()).toEqual(expectedKeys);
+      }
+    });
+
+    it('driver_metatag is null and driver_nationality is empty string (export shape)', () => {
+      const result: SynthDriver[] = synthesizeDriversFromNome('Solo Driver', '12');
+      expect(result[0].driver_metatag).toBeNull();
+      expect(result[0].driver_nationality).toBe('');
+    });
+  });
+
+  describe('regression: Lisa-style preset with 4 drivers', () => {
+    it('reproduces the #1 ROWE participant lineup verbatim', () => {
+      // From the 24h Nürburgring entry list — the exact case that triggered PR1.
+      const nome = 'Augusto Farfus, Raffaele Marciello, Jordan Pepper, Kelvin van der Linde';
+      const result: SynthDriver[] = synthesizeDriversFromNome(nome, '1');
+      expect(result).toHaveLength(4);
+      expect(result[0].driver_name).toBe('Augusto Farfus');
+      expect(result[3].driver_name).toBe('Kelvin van der Linde');
+      expect(result[3].driver_order).toBe(3);
+      expect(result[3].participant_numero).toBe('1');
+    });
+  });
+});


### PR DESCRIPTION
The top-level drivers[] array in the participant preset JSON export was populated only from preset_participant_drivers, which is sparse — rows exist only for participants opened/saved through the editor. PDF-imported presets keep multi-driver lineups in the legacy nome column as a comma-separated string and never get individual rows, so a round-trip silently dropped drivers 2/3/4 for every unedited participant.

On Lisa's 161-row Nürburgring 2026 preset only 7 cars kept their full lineup; 154 were collapsed to a single driver each.

Fix: when preset-get-drivers-for-participant returns 0 records, fall back to splitting participant.nome on commas via a new pure helper synthesizeDriversFromNome in renderer/js/driver-helpers.js. The export now matches what the UI grid already shows (smart-matcher.ts:90 has the same fallback).

Splitting policy: comma only. Slashes / semicolons preserved as-is (refusing to split 'J. Smith / co-driver TBD'). A console warning surfaces / occurrences so future data-uniformity work can clean those.

Tests: 21 cases in tests/driver-synthesis.test.ts covering empty inputs, single / multi names, whitespace, separator policy, shape contract, and a regression case from Lisa's #1 ROWE entry.

Refs: PLAN_BULK_FOLDER_ASSIGN.md (PR1)