### PR TITLE
feat(bulk-folders): IPC + DB layer for bulk folder assignment

### DIFF
--- a/src/database-service.ts
+++ b/src/database-service.ts
@@ -1988,6 +1988,262 @@ export async function savePresetParticipantsSupabase(presetId: string, participa
   }
 }
 
+// ============================================================================
+// Bulk folder assignment (PR2 — foundation for the split-view UI in PR3)
+// ============================================================================
+
+/**
+ * Result shape for bulkAssignFoldersSupabase. Per-row reporting lets the
+ * renderer surface partial success when one of N participants fails RLS or
+ * a transient network blip while the others go through.
+ */
+export interface BulkAssignFoldersResult {
+  ok: number;
+  failed: { id: string; error: string }[];
+  /** Folder names from the input that didn't exist in the preset's
+   *  custom_folders pool. The handler refuses these silently — surfacing
+   *  them lets the UI show a clear "create folder X first" hint. */
+  unknownFolderNames: string[];
+}
+
+/**
+ * Pure helper: compute the new folders[] array for a single participant given
+ * their current folders, the requested folder objects (already resolved to
+ * {name, path}), and the merge mode. Extracted so it can be unit-tested in
+ * isolation without a Supabase mock.
+ *
+ * Append mode: keep existing folders, add only those whose name is not
+ * already present (case-insensitive name comparison). Path on the existing
+ * entry wins — we don't overwrite a path the user may have customised.
+ *
+ * Replace mode: drop everything, set to exactly the requested folders in the
+ * given order.
+ */
+export function computeFolderUpdate(
+  currentFolders: { name: string; path?: string }[] | undefined | null,
+  requestedFolders: { name: string; path?: string }[],
+  mode: 'append' | 'replace'
+): { name: string; path?: string }[] {
+  if (mode === 'replace') {
+    // Defensive copy + filter to drop blanks.
+    return requestedFolders
+      .filter((f) => f && typeof f.name === 'string' && f.name.trim() !== '')
+      .map((f) => ({ name: f.name.trim(), ...(f.path ? { path: f.path } : {}) }));
+  }
+
+  // Append: case-insensitive dedup against existing names.
+  const existing = (Array.isArray(currentFolders) ? currentFolders : []).filter(
+    (f) => f && typeof f.name === 'string' && f.name.trim() !== ''
+  );
+  const existingKeys = new Set(existing.map((f) => f.name.trim().toLowerCase()));
+  const merged: { name: string; path?: string }[] = existing.map((f) => ({
+    name: f.name.trim(),
+    ...(f.path ? { path: f.path } : {})
+  }));
+
+  for (const f of requestedFolders) {
+    if (!f || typeof f.name !== 'string') continue;
+    const trimmed = f.name.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (existingKeys.has(key)) continue;
+    existingKeys.add(key);
+    merged.push({ name: trimmed, ...(f.path ? { path: f.path } : {}) });
+  }
+  return merged;
+}
+
+/**
+ * Atomically assign one or more folder names to many preset participants in a
+ * single Supabase round-trip. Used by the bulk-edit UI (PR3) and by the
+ * auto-assign rules engine (PR4).
+ *
+ * Folder names are looked up in the preset's `custom_folders` pool to attach
+ * the canonical filesystem path. Names not found in the pool are reported in
+ * `unknownFolderNames` and skipped — the caller is expected to surface them
+ * as a "create folder first" hint rather than failing the whole request.
+ *
+ * The legacy folder_1/2/3 columns are kept dual-written via the existing
+ * `applyDualWriteFolders` helper so 1.1.4 clients reading the same DB still
+ * see a valid first-three subset.
+ *
+ * @param presetId         UUID of the participant_presets row.
+ * @param participantIds   UUIDs of the preset_participants rows to mutate.
+ *                         Must all belong to `presetId`; foreign IDs are
+ *                         filtered out and reported in `failed`.
+ * @param folderNames      Folder names to assign (lookup against the preset's
+ *                         custom_folders pool).
+ * @param mode             'append' merges with existing folders, 'replace'
+ *                         overwrites them. Append is the default for safety
+ *                         and is what PR3's UI defaults to.
+ * @throws when the user is unauthenticated, the preset doesn't exist, or
+ *         RLS rejects the read.
+ */
+export async function bulkAssignFoldersSupabase(
+  presetId: string,
+  participantIds: string[],
+  folderNames: string[],
+  mode: 'append' | 'replace'
+): Promise<BulkAssignFoldersResult> {
+  const userId = getCurrentUserId();
+  if (!userId) throw new Error('User not authenticated');
+
+  if (!presetId) throw new Error('presetId is required');
+  if (mode !== 'append' && mode !== 'replace') {
+    throw new Error(`Invalid mode: ${mode} (expected 'append' or 'replace')`);
+  }
+
+  // Empty target set → no-op, return clean result so callers don't have to
+  // special-case it before invoking us.
+  if (!Array.isArray(participantIds) || participantIds.length === 0) {
+    return { ok: 0, failed: [], unknownFolderNames: [] };
+  }
+
+  const authenticatedClient = authService.getSupabaseClient();
+
+  // 1. Verify preset ownership and load custom_folders pool. The same query
+  //    serves two purposes: ownership check (404/403 if the user doesn't own
+  //    the preset) and folder-name → path lookup table for the assignment.
+  const { data: preset, error: presetError } = await authenticatedClient
+    .from('participant_presets')
+    .select('id, user_id, custom_folders')
+    .eq('id', presetId)
+    .single();
+
+  if (presetError) {
+    console.error('[DB BulkAssign] preset lookup failed:', presetError);
+    throw new Error(`Preset lookup failed: ${presetError.message}`);
+  }
+  if (!preset) {
+    throw new Error(`Preset ${presetId} not found`);
+  }
+  if (preset.user_id !== userId) {
+    console.error(`[DB BulkAssign] user mismatch: preset.user_id=${preset.user_id}, userId=${userId}`);
+    throw new Error('Access denied: preset belongs to another user');
+  }
+
+  // 2. Resolve folder names → {name, path} objects via the preset's pool.
+  //    Unknown names are reported back to the caller, not thrown — this lets
+  //    the UI show "Folder X doesn't exist yet, create it first" inline.
+  const pool: { name: string; path?: string }[] = Array.isArray(preset.custom_folders)
+    ? (preset.custom_folders as any[]).filter(
+        (f) => f && typeof f === 'object' && typeof f.name === 'string'
+      )
+    : [];
+  const poolByName = new Map<string, { name: string; path?: string }>();
+  for (const f of pool) {
+    poolByName.set(f.name.trim().toLowerCase(), { name: f.name.trim(), path: f.path });
+  }
+
+  const requestedFolders: { name: string; path?: string }[] = [];
+  const unknownFolderNames: string[] = [];
+  for (const raw of folderNames || []) {
+    if (typeof raw !== 'string') continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const resolved = poolByName.get(trimmed.toLowerCase());
+    if (resolved) {
+      requestedFolders.push(resolved);
+    } else {
+      unknownFolderNames.push(trimmed);
+    }
+  }
+
+  // Replace mode with no resolvable folders is a legitimate "clear all
+  // folders for these participants" action and proceeds. Append mode with
+  // nothing resolvable is a no-op — we return early to avoid an UPSERT that
+  // would just rewrite the same values.
+  if (mode === 'append' && requestedFolders.length === 0) {
+    return { ok: 0, failed: [], unknownFolderNames };
+  }
+
+  // 3. Load current folders for the target participants. The .in() filter
+  //    plus the preset_id check is our defense-in-depth: even if the caller
+  //    passes a participant ID from another preset, we don't touch it.
+  const { data: currentRows, error: currentError } = await authenticatedClient
+    .from('preset_participants')
+    .select('id, folders')
+    .eq('preset_id', presetId)
+    .in('id', participantIds);
+
+  if (currentError) {
+    console.error('[DB BulkAssign] current participants lookup failed:', currentError);
+    throw new Error(`Participant lookup failed: ${currentError.message}`);
+  }
+
+  const currentById = new Map<string, { folders?: { name: string; path?: string }[] }>();
+  for (const row of currentRows || []) {
+    currentById.set(row.id, { folders: (row as any).folders });
+  }
+
+  // Participants requested but not found under this preset → reported as
+  // failures rather than silently dropped. Either RLS hid them, or the
+  // caller passed a stale or cross-preset ID.
+  const failed: { id: string; error: string }[] = [];
+  for (const id of participantIds) {
+    if (!currentById.has(id)) {
+      failed.push({ id, error: 'Participant not found in this preset' });
+    }
+  }
+
+  // 4. Build the upsert payload. One row per resolvable participant, each
+  //    going through applyDualWriteFolders so the legacy folder_1/2/3
+  //    columns stay in sync for 1.1.4 clients.
+  const updatePayload = (currentRows || []).map((row) => {
+    const newFolders = computeFolderUpdate(
+      (row as any).folders,
+      requestedFolders,
+      mode
+    );
+    const record: any = {
+      id: row.id,
+      preset_id: presetId,
+      folders: newFolders
+    };
+    applyDualWriteFolders(record);
+    return record;
+  });
+
+  if (updatePayload.length === 0) {
+    return { ok: 0, failed, unknownFolderNames };
+  }
+
+  // 5. Single round-trip UPSERT. If Supabase returns a partial error we
+  //    cannot easily attribute it per-row, so we surface the global error
+  //    via thrown exception — the renderer can fall back to per-row updates
+  //    in the unlikely case this happens.
+  const { error: upsertError } = await authenticatedClient
+    .from('preset_participants')
+    .upsert(updatePayload, { onConflict: 'id' });
+
+  if (upsertError) {
+    console.error('[DB BulkAssign] bulk upsert failed:', upsertError);
+    throw new Error(`Bulk folder assignment failed: ${upsertError.message}`);
+  }
+
+  // 6. Cache invalidation — without this, a subsequent read inside the 30s
+  //    TTL window would return stale folders. Mirrors the pattern used by
+  //    togglePresetParticipantActive et al.
+  invalidatePresetCacheEntry(presetId);
+
+  // Bump preset updated_at so cache-by-timestamp consumers can detect it.
+  await authenticatedClient
+    .from('participant_presets')
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', presetId);
+
+  console.log(
+    `[DB BulkAssign] ✅ ${updatePayload.length} participants × ${requestedFolders.length} folders (${mode})` +
+    (unknownFolderNames.length > 0 ? ` · skipped unknown names: ${unknownFolderNames.join(', ')}` : '')
+  );
+
+  return {
+    ok: updatePayload.length,
+    failed,
+    unknownFolderNames
+  };
+}
+
 /**
  * Update preset last used timestamp in Supabase
  * Uses RPC function for atomic increment of usage_count

--- a/src/ipc/supabase-handlers.ts
+++ b/src/ipc/supabase-handlers.ts
@@ -21,6 +21,7 @@ import {
   getUserParticipantPresetsSupabase,
   getParticipantPresetByIdSupabase,
   savePresetParticipantsSupabase,
+  bulkAssignFoldersSupabase,
   updatePresetLastUsedSupabase,
   updateParticipantPresetSupabase,
   deleteParticipantPresetSupabase,
@@ -115,6 +116,34 @@ export function registerSupabaseHandlers(): void {
     try {
       const savedParticipants = await savePresetParticipantsSupabase(presetId, participants);
       return { success: true, participants: savedParticipants };
+    } catch (e: any) {
+      return { success: false, error: e.message };
+    }
+  });
+
+  /**
+   * Bulk-assign one or more folder names to many preset participants in a
+   * single round-trip. Backbone of the split-view bulk UI (PR3) and the
+   * auto-assign rules engine (PR4). Dormant until the renderer wires it up.
+   *
+   * Folder names must already exist in the preset's custom_folders pool;
+   * names not in the pool are skipped and reported in `unknownFolderNames`
+   * so the UI can show a "create folder first" hint.
+   */
+  ipcMain.handle('supabase-bulk-assign-folders', async (_, payload: {
+    presetId: string;
+    participantIds: string[];
+    folderNames: string[];
+    mode: 'append' | 'replace';
+  }) => {
+    try {
+      const result = await bulkAssignFoldersSupabase(
+        payload.presetId,
+        payload.participantIds,
+        payload.folderNames,
+        payload.mode
+      );
+      return { success: true, data: result };
     } catch (e: any) {
       return { success: false, error: e.message };
     }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -171,6 +171,7 @@ const validInvokeChannels: string[] = [
   'supabase-get-participant-presets',
   'supabase-get-participant-preset-by-id',
   'supabase-save-preset-participants',
+  'supabase-bulk-assign-folders',
   'supabase-update-participant-preset',
   'supabase-update-preset-last-used',
   'supabase-delete-participant-preset',

--- a/tests/bulk-assign-folders.test.ts
+++ b/tests/bulk-assign-folders.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for bulk folder assignment (PR2).
+ *
+ * Two layers:
+ *   1. `computeFolderUpdate` — pure function, exhaustive cases. The merge
+ *      semantics live here so the database round-trip stays thin.
+ *   2. `bulkAssignFoldersSupabase` — end-to-end against a mocked Supabase
+ *      client. Covers ownership, folder pool resolution, dual-write, cache
+ *      invalidation, and the partial-failure result shape.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+// ============================================================================
+// Module-level mock state for the auth + supabase singletons. Defined before
+// the jest.mock() calls so the factories can close over them.
+// ============================================================================
+
+let mockUserId: string | null = 'user-123';
+let mockSupabaseFromBuilder: any = null;
+
+jest.mock('../src/auth-service', () => ({
+  authService: {
+    getAuthState: () => ({
+      isAuthenticated: mockUserId !== null,
+      user: mockUserId ? { id: mockUserId } : null
+    }),
+    getSupabaseClient: () => ({
+      from: (table: string) => mockSupabaseFromBuilder(table)
+    })
+  }
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({ from: () => ({}) })
+}));
+
+// We need to load the module under test AFTER the mocks are set up.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const databaseService = require('../src/database-service');
+const { computeFolderUpdate, bulkAssignFoldersSupabase } = databaseService;
+
+// ============================================================================
+// Pure helper tests — these don't touch the auth/supabase mocks at all.
+// ============================================================================
+
+describe('computeFolderUpdate', () => {
+  describe('replace mode', () => {
+    it('returns exactly the requested folders, in order', () => {
+      const result = computeFolderUpdate(
+        [{ name: 'Old', path: '/old' }],
+        [{ name: 'A', path: '/a' }, { name: 'B', path: '/b' }],
+        'replace'
+      );
+      expect(result).toEqual([
+        { name: 'A', path: '/a' },
+        { name: 'B', path: '/b' }
+      ]);
+    });
+
+    it('drops blank/empty entries from the requested list', () => {
+      const result = computeFolderUpdate(
+        [],
+        [{ name: 'A', path: '/a' }, { name: '   ', path: '/blank' }, { name: 'B' }],
+        'replace'
+      );
+      expect(result).toHaveLength(2);
+      expect(result.map((f: any) => f.name)).toEqual(['A', 'B']);
+    });
+
+    it('clears folders when requested array is empty', () => {
+      const result = computeFolderUpdate(
+        [{ name: 'X', path: '/x' }, { name: 'Y' }],
+        [],
+        'replace'
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('omits the path key when not provided (does not store path: undefined)', () => {
+      const result = computeFolderUpdate(undefined, [{ name: 'NoPath' }], 'replace');
+      expect(result).toEqual([{ name: 'NoPath' }]);
+      expect(Object.keys(result[0])).toEqual(['name']);
+    });
+
+    it('trims surrounding whitespace from names', () => {
+      const result = computeFolderUpdate(undefined, [{ name: '  AMG  ' }], 'replace');
+      expect(result[0].name).toBe('AMG');
+    });
+  });
+
+  describe('append mode', () => {
+    it('keeps existing folders and adds new ones', () => {
+      const result = computeFolderUpdate(
+        [{ name: 'Existing', path: '/exist' }],
+        [{ name: 'Added', path: '/added' }],
+        'append'
+      );
+      expect(result).toEqual([
+        { name: 'Existing', path: '/exist' },
+        { name: 'Added', path: '/added' }
+      ]);
+    });
+
+    it('dedups case-insensitively against existing names', () => {
+      const result = computeFolderUpdate(
+        [{ name: 'AMG', path: '/amg' }],
+        [{ name: 'amg', path: '/different-path' }, { name: 'ADAC', path: '/adac' }],
+        'append'
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ name: 'AMG', path: '/amg' }); // existing path wins
+      expect(result[1]).toEqual({ name: 'ADAC', path: '/adac' });
+    });
+
+    it('dedups within the requested list itself', () => {
+      const result = computeFolderUpdate(
+        [],
+        [{ name: 'X', path: '/x1' }, { name: 'x', path: '/x2' }],
+        'append'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ name: 'X', path: '/x1' });
+    });
+
+    it('handles undefined / null current folders as empty', () => {
+      expect(computeFolderUpdate(undefined, [{ name: 'A', path: '/a' }], 'append'))
+        .toEqual([{ name: 'A', path: '/a' }]);
+      expect(computeFolderUpdate(null, [{ name: 'A', path: '/a' }], 'append'))
+        .toEqual([{ name: 'A', path: '/a' }]);
+    });
+
+    it('drops malformed entries from the existing list (defensive)', () => {
+      const dirty: any = [
+        { name: 'Good', path: '/good' },
+        null,
+        { path: '/no-name' },
+        { name: '   ' },
+        { name: 'Trim Me  ', path: '/trim' }
+      ];
+      const result = computeFolderUpdate(dirty, [{ name: 'Added' }], 'append');
+      expect(result.map((f: any) => f.name)).toEqual(['Good', 'Trim Me', 'Added']);
+    });
+
+    it('preserves order: existing first, new appended', () => {
+      const result = computeFolderUpdate(
+        [{ name: 'B' }, { name: 'A' }],
+        [{ name: 'D' }, { name: 'C' }],
+        'append'
+      );
+      expect(result.map((f: any) => f.name)).toEqual(['B', 'A', 'D', 'C']);
+    });
+  });
+});
+
+// ============================================================================
+// Integration-ish tests against a mocked Supabase client. We model the chain
+// of from(...).select(...).eq(...).single() and from(...).upsert(...) calls
+// using Jest mocks so we can assert the shape of payloads we send to Supabase.
+// ============================================================================
+
+interface FromBuilder {
+  select: jest.Mock;
+  eq: jest.Mock;
+  in: jest.Mock;
+  single: jest.Mock;
+  update: jest.Mock;
+  upsert: jest.Mock;
+  __table: string;
+  __resolveSelect?: () => Promise<{ data: any; error: any }>;
+  __resolveSingle?: () => Promise<{ data: any; error: any }>;
+  __resolveUpsert?: () => Promise<{ data: any; error: any }>;
+  __resolveUpdate?: () => Promise<{ data: any; error: any }>;
+}
+
+interface SupabaseHarness {
+  presetRow: any;
+  presetError: any;
+  participantRows: any[];
+  participantsError: any;
+  upsertError: any;
+  upsertedPayload: any[] | null;
+  /** Captured calls to from() in order, for assertion. */
+  fromCalls: { table: string; builder: FromBuilder }[];
+}
+
+function makeSupabaseHarness(overrides: Partial<SupabaseHarness> = {}): SupabaseHarness {
+  return {
+    presetRow: {
+      id: 'preset-1',
+      user_id: 'user-123',
+      custom_folders: [
+        { name: 'AMG', path: '/abs/AMG' },
+        { name: 'ADAC', path: '/abs/ADAC' },
+        { name: 'Schnitzelalm Heyer', path: '/abs/Schnitzelalm' }
+      ]
+    },
+    presetError: null,
+    participantRows: [
+      { id: 'p-1', folders: [] },
+      { id: 'p-2', folders: [{ name: 'AMG', path: '/abs/AMG' }] }
+    ],
+    participantsError: null,
+    upsertError: null,
+    upsertedPayload: null,
+    fromCalls: [],
+    ...overrides
+  };
+}
+
+function installFromBuilder(harness: SupabaseHarness): void {
+  mockSupabaseFromBuilder = (table: string) => {
+    const b: any = {
+      __table: table,
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      in: jest.fn().mockReturnThis(),
+      single: jest.fn(),
+      update: jest.fn().mockReturnThis(),
+      upsert: jest.fn()
+    };
+
+    if (table === 'participant_presets') {
+      // Two distinct call sites:
+      //   1. .select('id, user_id, custom_folders').eq('id', presetId).single()
+      //   2. .update({ updated_at }).eq('id', presetId)
+      b.single.mockImplementation(() =>
+        Promise.resolve({ data: harness.presetRow, error: harness.presetError })
+      );
+      b.update.mockImplementation(() => {
+        // Second .eq() resolves the chain — fake an awaitable
+        const continuation: any = {
+          eq: jest.fn().mockImplementation(() => Promise.resolve({ error: null }))
+        };
+        return continuation;
+      });
+    } else if (table === 'preset_participants') {
+      // .select('id, folders').eq('preset_id', presetId).in('id', participantIds)
+      // is awaited as a promise — make .in() resolve.
+      b.in.mockImplementation(() =>
+        Promise.resolve({
+          data: harness.participantRows,
+          error: harness.participantsError
+        })
+      );
+      b.upsert.mockImplementation((payload: any) => {
+        harness.upsertedPayload = payload;
+        return Promise.resolve({ data: null, error: harness.upsertError });
+      });
+    }
+
+    harness.fromCalls.push({ table, builder: b });
+    return b;
+  };
+}
+
+describe('bulkAssignFoldersSupabase', () => {
+  let harness: SupabaseHarness;
+
+  beforeEach(() => {
+    mockUserId = 'user-123';
+    harness = makeSupabaseHarness();
+    installFromBuilder(harness);
+  });
+
+  it('throws when user is not authenticated', async () => {
+    mockUserId = null;
+    await expect(
+      bulkAssignFoldersSupabase('preset-1', ['p-1'], ['AMG'], 'append')
+    ).rejects.toThrow(/not authenticated/i);
+  });
+
+  it('throws on invalid mode', async () => {
+    await expect(
+      bulkAssignFoldersSupabase('preset-1', ['p-1'], ['AMG'], 'merge' as any)
+    ).rejects.toThrow(/Invalid mode/i);
+  });
+
+  it('returns empty result when no participantIds given', async () => {
+    const result = await bulkAssignFoldersSupabase('preset-1', [], ['AMG'], 'append');
+    expect(result).toEqual({ ok: 0, failed: [], unknownFolderNames: [] });
+    expect(harness.fromCalls.length).toBe(0); // never even hit Supabase
+  });
+
+  it('throws when preset belongs to a different user', async () => {
+    harness.presetRow.user_id = 'someone-else';
+    await expect(
+      bulkAssignFoldersSupabase('preset-1', ['p-1'], ['AMG'], 'append')
+    ).rejects.toThrow(/Access denied/i);
+  });
+
+  it('reports unknown folder names without erroring out', async () => {
+    const result = await bulkAssignFoldersSupabase(
+      'preset-1',
+      ['p-1', 'p-2'],
+      ['AMG', 'NotInPool'],
+      'append'
+    );
+    expect(result.unknownFolderNames).toEqual(['NotInPool']);
+    expect(result.ok).toBe(2);
+  });
+
+  it('append mode merges with existing folders and dedups case-insensitively', async () => {
+    await bulkAssignFoldersSupabase('preset-1', ['p-1', 'p-2'], ['AMG', 'ADAC'], 'append');
+    expect(harness.upsertedPayload).toHaveLength(2);
+
+    const p1 = harness.upsertedPayload!.find((r: any) => r.id === 'p-1');
+    const p2 = harness.upsertedPayload!.find((r: any) => r.id === 'p-2');
+
+    // p-1 had no folders → both new ones land
+    expect(p1.folders.map((f: any) => f.name)).toEqual(['AMG', 'ADAC']);
+    // p-2 already had AMG → only ADAC is appended; existing AMG path preserved
+    expect(p2.folders).toHaveLength(2);
+    expect(p2.folders[0]).toEqual({ name: 'AMG', path: '/abs/AMG' });
+    expect(p2.folders[1]).toEqual({ name: 'ADAC', path: '/abs/ADAC' });
+  });
+
+  it('replace mode wipes existing folders and sets only the requested ones', async () => {
+    await bulkAssignFoldersSupabase('preset-1', ['p-1', 'p-2'], ['ADAC'], 'replace');
+    const p2 = harness.upsertedPayload!.find((r: any) => r.id === 'p-2');
+    // p-2 used to have AMG; replace mode kicks it out
+    expect(p2.folders).toEqual([{ name: 'ADAC', path: '/abs/ADAC' }]);
+  });
+
+  it('replace mode with empty folder list clears all folders for the participants', async () => {
+    await bulkAssignFoldersSupabase('preset-1', ['p-1', 'p-2'], [], 'replace');
+    expect(harness.upsertedPayload).toHaveLength(2);
+    for (const row of harness.upsertedPayload!) {
+      expect(row.folders).toEqual([]);
+      expect(row.folder_1).toBeNull();
+      expect(row.folder_2).toBeNull();
+      expect(row.folder_3).toBeNull();
+    }
+  });
+
+  it('append mode with no resolvable folders is a no-op (does not upsert)', async () => {
+    const result = await bulkAssignFoldersSupabase(
+      'preset-1',
+      ['p-1', 'p-2'],
+      ['NotAPoolName'],
+      'append'
+    );
+    expect(harness.upsertedPayload).toBeNull(); // upsert never called
+    expect(result.ok).toBe(0);
+    expect(result.unknownFolderNames).toEqual(['NotAPoolName']);
+  });
+
+  it('writes legacy folder_1/2/3 columns alongside the canonical folders[]', async () => {
+    await bulkAssignFoldersSupabase('preset-1', ['p-1'], ['AMG', 'ADAC', 'Schnitzelalm Heyer'], 'append');
+    const row = harness.upsertedPayload!.find((r: any) => r.id === 'p-1');
+    expect(row.folder_1).toBe('AMG');
+    expect(row.folder_1_path).toBe('/abs/AMG');
+    expect(row.folder_2).toBe('ADAC');
+    expect(row.folder_2_path).toBe('/abs/ADAC');
+    expect(row.folder_3).toBe('Schnitzelalm Heyer');
+    expect(row.folder_3_path).toBe('/abs/Schnitzelalm');
+  });
+
+  it('reports participantIds that do not belong to the preset as failures', async () => {
+    // We requested 3 IDs but Supabase returns rows for only 2 (RLS or wrong preset).
+    const result = await bulkAssignFoldersSupabase(
+      'preset-1',
+      ['p-1', 'p-2', 'p-foreign'],
+      ['AMG'],
+      'append'
+    );
+    expect(result.ok).toBe(2);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]).toEqual({ id: 'p-foreign', error: 'Participant not found in this preset' });
+  });
+
+  it('throws when Supabase returns an error on the upsert', async () => {
+    harness.upsertError = { message: 'transient db blip' };
+    await expect(
+      bulkAssignFoldersSupabase('preset-1', ['p-1'], ['AMG'], 'append')
+    ).rejects.toThrow(/Bulk folder assignment failed.*transient db blip/);
+  });
+
+  it('throws when preset lookup fails', async () => {
+    harness.presetError = { message: 'rls denied' };
+    await expect(
+      bulkAssignFoldersSupabase('preset-1', ['p-1'], ['AMG'], 'append')
+    ).rejects.toThrow(/Preset lookup failed.*rls denied/);
+  });
+
+  it('throws when preset does not exist', async () => {
+    harness.presetRow = null;
+    await expect(
+      bulkAssignFoldersSupabase('preset-1', ['p-1'], ['AMG'], 'append')
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('handles a preset with no custom_folders pool gracefully', async () => {
+    harness.presetRow.custom_folders = null;
+    const result = await bulkAssignFoldersSupabase(
+      'preset-1',
+      ['p-1'],
+      ['AMG'],
+      'append'
+    );
+    // Every requested name is unknown because the pool is empty.
+    expect(result.unknownFolderNames).toEqual(['AMG']);
+    expect(result.ok).toBe(0);
+  });
+});


### PR DESCRIPTION
Foundation for the split-view bulk-edit UI (PR3) and the auto-assign rules engine (PR4). This PR ships the backend only — no UI calls the new handler yet, so it is functionally dormant in production.

Adds bulkAssignFoldersSupabase(presetId, participantIds, folderNames, mode) which assigns one or more folder names from the preset's custom_folders pool to many preset_participants rows in a single Supabase upsert round-trip. Modes are 'append' (merge with existing, case-insensitive dedup, existing path wins) and 'replace' (overwrite the participant's folders[] with the requested set).

Folder names are resolved against the preset's custom_folders pool to attach the canonical filesystem path. Names not in the pool are returned via unknownFolderNames so the UI can surface a 'create folder first' hint instead of failing the whole request. Participants whose IDs do not belong to the preset (RLS, stale UI, cross-preset request) are reported in the failed[] array, so the renderer can show partial success cleanly.

Reuses the existing applyDualWriteFolders helper (database-service.ts:1731) to keep the legacy folder_1/2/3 columns in sync for 1.1.4 clients sharing the same Supabase backend. Folders 4+ live only in folders[] as per the documented 1.2.0-exclusive behavior.

The merge logic is extracted as a pure helper computeFolderUpdate so it can be unit-tested in isolation without a Supabase mock.

Cache hygiene: invalidatePresetCacheEntry is called on success so the 30s TTL doesn't return stale folders to the next preset read.

Tests: 26 cases in tests/bulk-assign-folders.test.ts split between the pure helper (replace/append semantics, dedup, malformed input, trim) and the integration flow against a mocked Supabase client (auth, ownership, partial failure, unknown folder names, dual-write verification, error propagation).

Refs: PLAN_BULK_FOLDER_ASSIGN.md (PR2)