### PR TITLE
feat(visualTagging): forward grounding signals to edge function (#159)

### DIFF
--- a/src/unified-image-processor.ts
+++ b/src/unified-image-processor.ts
@@ -3546,7 +3546,7 @@ class UnifiedImageWorker extends EventEmitter {
                 faceVisualTagsResult = await this.invokeVisualTagging(faceRecognitionStoragePath, {
                   imageId: faceRecognitionImageId,
                   analysis: matchedDrivers
-                });
+                }, this.buildVisualTaggingAnchor(processor, imageFile.originalPath));
                 if (faceVisualTagsResult) {
                   workerLog.info(`[FaceRecognition] Visual tags extracted: ${Object.values(faceVisualTagsResult.tags).flat().length} tags`);
                 }
@@ -3668,7 +3668,7 @@ class UnifiedImageWorker extends EventEmitter {
         const [cropContextResult, parallelVisualTags] = await Promise.all([
           this.analyzeWithCropContext(imageFile, buffer, mimeType, uploadReadyPath, storagePath, processor),
           visualTaggingEnabled
-            ? this.invokeVisualTagging(storagePath, null).catch(err => {
+            ? this.invokeVisualTagging(storagePath, null, this.buildVisualTaggingAnchor(processor, imageFile.originalPath)).catch(err => {
                 log.warn(`[VisualTagging] Failed in parallel (continuing): ${err.message}`);
                 return null;
               })
@@ -3731,7 +3731,7 @@ class UnifiedImageWorker extends EventEmitter {
         const [onnxResult, onnxParallelVisualTags] = await Promise.all([
           this.analyzeImageLocal(buffer, imageFile.fileName, mimeType, storagePath),
           onnxVisualTaggingEnabled
-            ? this.invokeVisualTagging(storagePath, null).catch(err => {
+            ? this.invokeVisualTagging(storagePath, null, this.buildVisualTaggingAnchor(processor, imageFile.originalPath)).catch(err => {
                 log.warn(`[VisualTagging] Failed in parallel with ONNX (continuing): ${err.message}`);
                 return null;
               })
@@ -3790,7 +3790,7 @@ class UnifiedImageWorker extends EventEmitter {
         const [stdAnalysisResult, stdParallelVisualTags] = await Promise.all([
           this.analyzeImage(imageFile.fileName, storagePath, buffer.length, mimeType),
           stdVisualTaggingEnabled
-            ? this.invokeVisualTagging(storagePath, null).catch(err => {
+            ? this.invokeVisualTagging(storagePath, null, this.buildVisualTaggingAnchor(processor, imageFile.originalPath)).catch(err => {
                 log.warn(`[VisualTagging] Failed in parallel (continuing): ${err.message}`);
                 return null;
               })
@@ -3863,7 +3863,7 @@ class UnifiedImageWorker extends EventEmitter {
       } else if (this.config.visualTagging?.enabled && storagePath && !this.shouldUseCropContext() && !this.shouldUseLocalOnnx()) {
         // Fallback: Only run sequentially if not already parallelized (shouldn't happen normally)
         try {
-          visualTagsResult = await this.invokeVisualTagging(storagePath, analysisResult);
+          visualTagsResult = await this.invokeVisualTagging(storagePath, analysisResult, this.buildVisualTaggingAnchor(processor, imageFile.originalPath));
         } catch (err: any) {
           log.warn(`[VisualTagging] Failed (continuing without tags): ${err.message}`);
         }
@@ -5097,12 +5097,41 @@ class UnifiedImageWorker extends EventEmitter {
   }
 
   /**
+   * Build the calendar-anchor metadata payload for the visualTagging edge function.
+   * `processor` exposes `getPhotoMetadataForDB(path)` which reads EXIF data populated
+   * during temporal-clustering. Returns only the 3 fields the edge function consumes
+   * for grounding (photo_taken_at, photo_latitude, photo_longitude). Issue #159.
+   */
+  private buildVisualTaggingAnchor(
+    processor: UnifiedImageProcessor | undefined,
+    originalPath: string
+  ): { photo_taken_at?: string; photo_latitude?: number; photo_longitude?: number } {
+    if (!processor) return {};
+    const meta = processor.getPhotoMetadataForDB(originalPath) || {};
+    const out: { photo_taken_at?: string; photo_latitude?: number; photo_longitude?: number } = {};
+    if (typeof meta.photo_taken_at === 'string') out.photo_taken_at = meta.photo_taken_at;
+    if (typeof meta.photo_latitude === 'number') out.photo_latitude = meta.photo_latitude;
+    if (typeof meta.photo_longitude === 'number') out.photo_longitude = meta.photo_longitude;
+    return out;
+  }
+
+  /**
    * Visual Tagging: Invokes the visualTagging edge function to extract visual descriptive tags
    * Runs in parallel with recognition for zero additional latency
+   *
+   * `anchorMeta` (optional) enables the calendar anchor in the edge function:
+   * we forward preset_name + sport_category + photo_taken_at + GPS (when available)
+   * so the edge function can ground location_tags via event_calendar lookup.
+   * Issue #159.
    */
   private async invokeVisualTagging(
     storagePath: string,
-    analysisResult: any | null  // Now accepts null for parallel execution
+    analysisResult: any | null,  // Now accepts null for parallel execution
+    anchorMeta?: {
+      photo_taken_at?: string;
+      photo_latitude?: number;
+      photo_longitude?: number;
+    } | null
   ): Promise<{ tags: any; usage: any } | null> {
     // Only run if visual tagging is enabled
     if (!this.config.visualTagging?.enabled) {
@@ -5136,6 +5165,25 @@ class UnifiedImageWorker extends EventEmitter {
         };
       }
 
+      // Calendar anchor grounding signals (issue #159).
+      // Caller pre-extracts photo_taken_at/lat/lon from EXIF metadata; we forward
+      // them to the edge function alongside preset_name + sport_category.
+      // All fields are optional — edge function falls back to vanilla Gemini if missing.
+      const anchorFields: {
+        preset_name?: string;
+        sport_category?: string;
+        photo_taken_at?: string;
+        photo_latitude?: number;
+        photo_longitude?: number;
+      } = {};
+      if (this.config.presetName) anchorFields.preset_name = this.config.presetName;
+      if (this.config.category) anchorFields.sport_category = this.config.category;
+      if (anchorMeta) {
+        if (anchorMeta.photo_taken_at) anchorFields.photo_taken_at = anchorMeta.photo_taken_at;
+        if (typeof anchorMeta.photo_latitude === 'number') anchorFields.photo_latitude = anchorMeta.photo_latitude;
+        if (typeof anchorMeta.photo_longitude === 'number') anchorFields.photo_longitude = anchorMeta.photo_longitude;
+      }
+
       const response = await Promise.race([
         this.supabase.functions.invoke('visualTagging', {
           body: {
@@ -5143,7 +5191,8 @@ class UnifiedImageWorker extends EventEmitter {
             imageId: analysisResult?.imageId || '',
             executionId: this.config.executionId || '',
             userId: userId || '',
-            recognitionResult  // undefined when running in parallel (edge function handles this)
+            recognitionResult,  // undefined when running in parallel (edge function handles this)
+            ...anchorFields
           }
         }),
         new Promise((_, reject) =>


### PR DESCRIPTION
## Summary

Companion desktop PR for [#159](https://github.com/fedepasi/racetagger-desktop-v2/issues/159) (visual tagging hallucinates locations — NBR 24h photos mis-tagged as Le Mans).

Wires preset_name, sport_category, photo_taken_at and GPS coords into every \`invokeVisualTagging\` call so the edge function can ground location_tags via \`event_calendar\` lookup.

## Changes

All in \`src/unified-image-processor.ts\`:

- New helper \`buildVisualTaggingAnchor(processor, originalPath)\` extracts \`photo_taken_at\` / \`photo_latitude\` / \`photo_longitude\` from the EXIF metadata cache already populated for \`analysis_results\` (PR #149).
- \`invokeVisualTagging\` signature gets optional 3rd param \`anchorMeta\`. \`preset_name\` and \`sport_category\` come from \`this.config\`.
- All 5 invoke sites updated: face-recognition, cropContext parallel, ONNX parallel, standard parallel, sequential fallback.

Anchor fields are all optional → edge function falls back to vanilla Gemini when none provided. No schema/migration changes.

## Companion PR

Edge function side: [fedepasi/RaceTagger#20](https://github.com/fedepasi/RaceTagger/pull/20) (branch \`feat/visual-tagging-grounding-mvp\`). New module \`calendar-anchor.ts\` does the actual lookup chain (preset fuzzy → photo_taken_at ±3d → GPS Haversine) and injects the hint into the Gemini prompt.

## Status — DRAFT, do NOT merge yet

This PR is draft on purpose. Before flipping ready:

- [ ] Founder runs empirical test in \`/experiments/visual-tag-grounding/\` to validate that the anchor hint actually changes Gemini output (premise check)
- [ ] Companion edge function PR (#20 on RaceTagger) deployed to a Supabase **branch** (not prod)
- [ ] Re-run on Gruppe C NBR 2026-05-14 batch and verify success metric defined in \`.studio/state/visual-tagging-mvp-success-metric.md\` (≥90% photos with \`nürburg|nurburg|eifel\` location_tag, 0 with \`le mans|sarthe\`)
- [ ] Verify Motorsport_v3 has rows in \`event_calendar\` for that timeframe (else anchor never fires)

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] Existing tests: 45/385 fail but all pre-existing (scene-classifier-onnx Float32Array runtime, jpeg-metadata case-sensitive) — none touch the modified code path
- [ ] End-to-end: process the NBR 24h batch with the new edge function deployed on Supabase branch and confirm location_tags grounded

Closes #159 (after deployment + empirical validation).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>